### PR TITLE
Converts FluxComponent to use cloneElement

### DIFF
--- a/src/components/FluxComponent.js
+++ b/src/components/FluxComponent.js
@@ -1,5 +1,4 @@
 import { default as React, PropTypes } from 'react';
-import cloneWithProps from 'react/addons/cloneWithProps';
 import Flux from '../Flux';
 import assign from 'object-assign';
 
@@ -25,9 +24,7 @@ class FluxComponent extends React.Component {
     wrapChild(child) {
         let actions = this.collectActions(this.props.actions, this.props.actionsGetter);
         let props = assign({}, this.state, actions);
-        // Using deprecated cloneWithProps. With cloneElement, flux would be undefined
-        // https://github.com/facebook/react/issues/3392
-        return cloneWithProps(child, props);
+        return React.cloneElement(child, props);
     }
 
     render() {


### PR DESCRIPTION
I'm starting to see errors that `react/addons/cloneWithProps`  cannot be resolved now.  This converts it to using the non-deprecated cloneElement.  Based on the issue that was in the comment I'm removing, it seems problems are resolved.  In my albeit limited testing it worked just fine.
